### PR TITLE
Use 0.0.0.0 ('not applicable' meta IP address) when $_SERVER is missing

### DIFF
--- a/src/icepay_api_webservice.php
+++ b/src/icepay_api_webservice.php
@@ -217,7 +217,7 @@ class Icepay_Webservice_Base extends Icepay_Api_Base {
      */
     protected function getIP()
     {
-        return $_SERVER['REMOTE_ADDR'];
+        return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '0.0.0.0';
     }
 
     /**


### PR DESCRIPTION
When processing recurring payments from a cron job I noticed that $_SERVER['REMOTE_ADDR'] was still used. Because this superglobal is not available during PHP CLI sessions I made sure 0.0.0.0 is sent instead to prevent an empty IP address being sent to the web service.